### PR TITLE
Add ClusterJoinURL and appContainerName processing for sidecar

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -37,9 +37,11 @@ func init() {
 }
 
 func main() {
+	var clusterJoinURL string
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	flag.StringVar(&clusterJoinURL, "cluster-join-url", ":", "The address the eg master binds to.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -67,10 +69,11 @@ func main() {
 	}
 
 	if err = (&controllers.MeshDeploymentReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("MeshDeployment"),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("controller.MeshDeployment"),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("MeshDeployment"),
+		Scheme:         mgr.GetScheme(),
+		ClusterJoinURL: clusterJoinURL,
+		Recorder:       mgr.GetEventRecorderFor("controller.MeshDeployment"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MeshDeployment")
 		os.Exit(1)

--- a/cmd/operator/pkg/api/v1beta1/meshdeployment_types.go
+++ b/cmd/operator/pkg/api/v1beta1/meshdeployment_types.go
@@ -15,7 +15,8 @@ import (
 // ServiceSpec describes mesh service properties
 type ServiceSpec struct {
 	//Name is mesh service name of the deployment
-	Name string `json:"name"`
+	Name             string `json:"name"`
+	AppContainerName string `json:"appContainerName"`
 	//Labels is dedicated to labeling instance of deployment for traffic control
 	Labels map[string]string `json:"labels"`
 }

--- a/cmd/operator/pkg/controllers/meshdeployment_controller.go
+++ b/cmd/operator/pkg/controllers/meshdeployment_controller.go
@@ -24,9 +24,10 @@ import (
 // MeshDeploymentReconciler reconciles a MeshDeployment object
 type MeshDeploymentReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	Recorder       record.EventRecorder
+	ClusterJoinURL string
 }
 
 // +kubebuilder:rbac:groups=mesh.megaease.com,resources=meshdeployments,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
- Add ClusterJoinURL operator args and pass it to sidecar
- Add AppContainerName in MeshDeployment ServiceSpec, then getting the contaienrPort according to AppContainerName and pass port to sidecar 