### PR TITLE
Update applicaton port configuration

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -203,7 +203,7 @@ spec:
   service:
     name: ${your-service-name}
     labels:
-    - version: canary       # These map is used to label these canary instances
+      version: canary       # These map is used to label these canary instances
   deploy:                   # K8s native deployment spec contents
     replicas: 2
     selector:

--- a/operator/pkg/controllers/resourcesyncer/deployment.go
+++ b/operator/pkg/controllers/resourcesyncer/deployment.go
@@ -364,11 +364,14 @@ func (d *deploySyncer) sidecarInitContainer(deploy *v1.Deployment) (corev1.Conta
 	applicationPort, ok := d.meshDeployment.Spec.Service.Labels[sideCarApplicationPortLabel]
 	if ok {
 		params.Labels[sideCarApplicationPortLabel] = applicationPort
+		d.log.V(0).Info("Using application-port", "MeshDeploymentName", d.meshDeployment.Name,
+			"application-port", applicationPort)
 	} else if len(appContainer.Ports) != 0 {
 		port := appContainer.Ports[0].ContainerPort
 		params.Labels[sideCarApplicationPortLabel] = strconv.Itoa(int(port))
 		d.log.V(0).Info("No application-port label is set, so we use the first Port of "+
-			"the application container as the application-port to forward traffic.", "MeshDeploymentName", d.meshDeployment.Name)
+			"the application container as the application-port to forward traffic.", "MeshDeploymentName", d.meshDeployment.Name,
+			"application-port", port)
 	}
 
 	livenessProbe := appContainer.LivenessProbe

--- a/operator/pkg/controllers/resourcesyncer/deployment.go
+++ b/operator/pkg/controllers/resourcesyncer/deployment.go
@@ -361,15 +361,15 @@ func (d *deploySyncer) sidecarInitContainer(deploy *v1.Deployment) (corev1.Conta
 		return initContainer, err
 	}
 
-	applicationPort, ok := d.meshDeployment.Spec.Service.Labels[sideCarApplicationPortLabel]
-	if ok {
+	applicationPort := d.meshDeployment.Spec.Service.Labels[sideCarApplicationPortLabel]
+	if len(applicationPort) != 0 {
 		params.Labels[sideCarApplicationPortLabel] = applicationPort
 		d.log.V(0).Info("Using application-port", "MeshDeploymentName", d.meshDeployment.Name,
 			"application-port", applicationPort)
 	} else if len(appContainer.Ports) != 0 {
 		port := appContainer.Ports[0].ContainerPort
 		params.Labels[sideCarApplicationPortLabel] = strconv.Itoa(int(port))
-		d.log.V(0).Info("No application-port label is set, so we use the first Port of "+
+		d.log.V(0).Info("No application-port label is set, so we use the first port of "+
 			"the application container as the application-port to forward traffic.", "MeshDeploymentName", d.meshDeployment.Name,
 			"application-port", port)
 	}


### PR DESCRIPTION
Modify the processing logic of the application-port parameter. 
- If the value passed by the user is preferentially used.
- if not passed, the first port of the application container is used.