### PR TITLE
Fix some problems of the emctl

### DIFF
--- a/emctl/cmd/client/command/apply/apply.go
+++ b/emctl/cmd/client/command/apply/apply.go
@@ -31,15 +31,19 @@ import (
 )
 
 // Run is the entrypoint of the emctl apply subcommand
-func Run(cmd *cobra.Command, flags *flags.Apply) {
-	if flags.YamlFile == "" {
+func Run(cmd *cobra.Command, flag *flags.Apply) {
+	if flag.Server == "" {
+		flag.Server = flags.GetServerAddress()
+	}
+
+	if flag.YamlFile == "" {
 		common.ExitWithErrorf("no resource specified")
 	}
 
 	vss, err := util.NewVisitorBuilder().
 		FilenameParam(&util.FilenameOptions{
-			Recursive: flags.Recursive,
-			Filenames: []string{flags.YamlFile},
+			Recursive: flag.Recursive,
+			Filenames: []string{flag.YamlFile},
 		}).
 		Do()
 
@@ -54,7 +58,7 @@ func Run(cmd *cobra.Command, flags *flags.Apply) {
 				return errors.Wrap(e, "visit failed")
 			}
 
-			err := WrapApplierByMeshObject(mo, meshclient.New(flags.Server), flags.Timeout).Apply()
+			err := WrapApplierByMeshObject(mo, meshclient.New(flag.Server), flag.Timeout).Apply()
 			if err != nil {
 				return fmt.Errorf("%s/%s applied failed: %s", mo.Kind(), mo.Name(), err)
 			}

--- a/emctl/cmd/client/command/delete/delete.go
+++ b/emctl/cmd/client/command/delete/delete.go
@@ -31,17 +31,22 @@ import (
 )
 
 // Run is the entrypoint of the emctl delete sub command
-func Run(cmd *cobra.Command, flags *flags.Delete) {
+func Run(cmd *cobra.Command, flag *flags.Delete) {
+
+	if flag.Server == "" {
+		flag.Server = flags.GetServerAddress()
+	}
+
 	visitorBulder := util.NewVisitorBuilder()
 
 	cmdArgs := cmd.Flags().Args()
 
-	if len(cmdArgs) == 0 && flags.YamlFile == "" {
+	if len(cmdArgs) == 0 && flag.YamlFile == "" {
 		common.ExitWithErrorf("no resource specified")
 	}
 
 	if len(cmdArgs) != 0 {
-		if flags.YamlFile != "" {
+		if flag.YamlFile != "" {
 			common.ExitWithErrorf("file and command args are both specified")
 		}
 		if len(cmdArgs) != 2 {
@@ -53,10 +58,10 @@ func Run(cmd *cobra.Command, flags *flags.Delete) {
 		})
 	}
 
-	if flags.YamlFile != "" {
+	if flag.YamlFile != "" {
 		visitorBulder.FilenameParam(&util.FilenameOptions{
-			Recursive: flags.Recursive,
-			Filenames: []string{flags.YamlFile},
+			Recursive: flag.Recursive,
+			Filenames: []string{flag.YamlFile},
 		})
 	}
 
@@ -72,7 +77,7 @@ func Run(cmd *cobra.Command, flags *flags.Delete) {
 				return errors.Wrap(e, "visit failed")
 			}
 
-			err := WrapDeleterByMeshObject(mo, meshclient.New(flags.Server), flags.Timeout).Delete()
+			err := WrapDeleterByMeshObject(mo, meshclient.New(flag.Server), flag.Timeout).Delete()
 			if err != nil {
 				return errors.Wrapf(err, "%s/%s deleted failed", mo.Kind(), mo.Name())
 			}

--- a/emctl/cmd/client/command/flags/flags.go
+++ b/emctl/cmd/client/command/flags/flags.go
@@ -201,24 +201,19 @@ type (
 	}
 )
 
-var (
-	globalRCFile *rcfile.RCFile
-)
-
-func init() {
+// GetServerAddress return global server address configuration
+func GetServerAddress() string {
 	rc, err := rcfile.New()
 	if err != nil {
-		globalRCFile = &rcfile.RCFile{}
-		common.OutputErrorf("new rcfile failed: %v", err)
-		return
+		return ""
 	}
 
 	err = rc.Unmarshal()
 	if err != nil {
 		common.OutputErrorf("unmarshal rcfile failed: %v", err)
+		return ""
 	}
-
-	globalRCFile = rc
+	return rc.Server
 }
 
 // AttachCmd attaches options for installation sub command
@@ -270,12 +265,7 @@ func (o *OperationGlobal) AttachCmd(cmd *cobra.Command) {
 
 // AttachCmd attaches options for base administrator command
 func (a *AdminGlobal) AttachCmd(cmd *cobra.Command) {
-	server := "127.0.0.1:2381"
-	if globalRCFile.Server != "" {
-		server = globalRCFile.Server
-	}
-
-	cmd.Flags().StringVarP(&a.Server, "server", "s", server, "An address to access the EaseMesh control plane")
+	cmd.Flags().StringVarP(&a.Server, "server", "s", "", "An address to access the EaseMesh control plane")
 	cmd.Flags().DurationVarP(&a.Timeout, "timeout", "t", 30*time.Second, "A duration that limit max time out for requesting the EaseMesh control plane")
 }
 

--- a/emctl/cmd/client/command/get/get.go
+++ b/emctl/cmd/client/command/get/get.go
@@ -30,12 +30,15 @@ import (
 )
 
 // Run is the entrypoint of the get sub command
-func Run(cmd *cobra.Command, flags *flags.Get) {
-	switch flags.OutputFormat {
+func Run(cmd *cobra.Command, flag *flags.Get) {
+	if flag.Server == "" {
+		flag.Server = flags.GetServerAddress()
+	}
+	switch flag.OutputFormat {
 	case "table", "yaml", "json":
 	default:
 		common.ExitWithErrorf("unsupported output format %s (support table, yaml, json)",
-			flags.OutputFormat)
+			flag.OutputFormat)
 	}
 
 	visitorBulder := util.NewVisitorBuilder()
@@ -63,7 +66,7 @@ func Run(cmd *cobra.Command, flags *flags.Get) {
 		common.ExitWithErrorf("build visitor failed: %s", err)
 	}
 
-	printer := printer.New(flags.OutputFormat)
+	printer := printer.New(flag.OutputFormat)
 	var errs []error
 	for _, vs := range vss {
 		err := vs.Visit(func(mo resource.MeshObject, e error) error {
@@ -76,7 +79,7 @@ func Run(cmd *cobra.Command, flags *flags.Get) {
 				resourceID += "/" + mo.Name()
 			}
 
-			objects, err := WrapGetterByMeshObject(mo, meshclient.New(flags.Server), flags.Timeout).Get()
+			objects, err := WrapGetterByMeshObject(mo, meshclient.New(flag.Server), flag.Timeout).Get()
 			if err != nil {
 				return errors.Wrapf(err, "%s get failed", resourceID)
 			}

--- a/emctl/cmd/client/command/mesh_install.go
+++ b/emctl/cmd/client/command/mesh_install.go
@@ -125,9 +125,10 @@ func postInstall(context *installbase.StageContext) {
 
 	nodes, err := context.Client.CoreV1().Nodes().List(stdcontext.TODO(), metav1.ListOptions{})
 	if err != nil {
-		common.OutputErrorf("ignored: get nodes information failed: %v", err)
+		common.OutputErrorf("ignored: get nodes' information failed: %v", err)
 		return
 	}
+
 	firstNodeIP := ""
 	for _, n := range nodes.Items {
 		for _, address := range n.Status.Addresses {

--- a/emctl/cmd/client/command/meshinstall/controlpanel/provision.go
+++ b/emctl/cmd/client/command/meshinstall/controlpanel/provision.go
@@ -61,7 +61,8 @@ func provisionEaseMeshControlPanel(cmd *cobra.Command, kubeClient *kubernetes.Cl
 		_, err = client.NewHTTPJSON().
 			Post(url, configBody, time.Second*5, nil).
 			HandleResponse(func(body []byte, statusCode int) (interface{}, error) {
-				if statusCode >= 400 {
+				if statusCode >= 400 && statusCode != 409 {
+					// 409 represents mesh_controller already enabled ?
 					return nil, errors.Errorf("setup EaseMesh controller panel error, controller panel return statusCode %d, body: %s", statusCode, string(body))
 				}
 				return nil, nil


### PR DESCRIPTION
Fix some problems of the `emctl`:

1.  Not all sub-command need to load the `.emctlrc` file, change to lazy reading policy.
2. MeshController could be enabled, (in the case that users reinstall mesh without clear PV/PVC resource), just ignore 409 status code when provisioning mesh controller configuration.
3. Write the correct address to the `.emctlrc` file.