### PR TITLE
[doc] add protocol's optional section

### DIFF
--- a/docs/sidecar_protocol.md
+++ b/docs/sidecar_protocol.md
@@ -11,14 +11,15 @@ There are three types of traffic that are managed by EaseMesh.
 * Second, the **Health-checking HTTP traffic**. This traffic is sent from the sidecar to the Java application's additional port opened by EaseAgent.  The complete URI is `http://localhost:9000/health` by default. This `9000` port is opened by EaseAgent, sidecar will query this URI period for checking the liveness of the Java application. After successfully deployed, sidecar will registry this instance into EaseMesh automatically after confirming the HTTP 200 success return by this URI.
 * Third, the **Service-discovery traffic**. This traffic is invoked by the Java spring cloud application's RPC framework. During the lifetime of the Java application, sidecar will work as the Java application's service registry and discovery center. EaseMesh sidecar implements Eureka/Consul/Naocs APIs for hosting the Java application's registry and discovery requests. To make the sidecar server the registry and discovery center, value it with `http://localhost:13009` inside the Java application's  XML. The port `13009` is listened by sidecar for handling Eureka/Consul/Nacos APIs. 
 
-The ports used by EaseMesh sidecar+agnet system
+The ports inside EaseMesh Pod
 
-| Role    | Port  | Description                                                                                                                 |
-| ------- | ----- | --------------------------------------------------------------------------------------------------------------------------- |
-| Sidecar | 13001 | The default Ingress port listened by sidecar for handing over traffic to local Java application                             |
-| Sidecar | 13002 | The default egress port listened by sidecar for routing local Java applications RPC request to another Java application     |
-| Sidecar | 13009 | The default registry and discovery port listened by sidecar, for handling local Java application's Eureka/Conslu/Nacos APIs |
-| Agent   | 9000  | The default health port listened by Agent queried by sidecar for checking the liveness of Java application                  |
+| Role        | Port       | Description                                                                                                                 |
+| ----------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Sidecar     | 13001      | The default Ingress port listened by sidecar for handing over traffic to local Java application                             |
+| Sidecar     | 13002      | The default egress port listened by sidecar for routing local Java applications RPC request to another Java application     |
+| Sidecar     | 13009      | The default registry and discovery port listened by sidecar, for handling local Java application's Eureka/Conslu/Nacos APIs |
+| Agent       | 9000       | The default health port listened by Agent queried by sidecar for checking the liveness of Java application                  |
+| Application | customized | The port listened by Java application. Sidecar will use it for routing ingress traffic                                      |
 
 
 

--- a/docs/sidecar_protocol.md
+++ b/docs/sidecar_protocol.md
@@ -13,13 +13,13 @@ There are three types of traffic that are managed by EaseMesh.
 
 The ports inside EaseMesh Pod
 
-| Role        | Port       | Description                                                                                                                 |
-| ----------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Sidecar     | 13001      | The default Ingress port listened by sidecar for handing over traffic to local Java application                             |
-| Sidecar     | 13002      | The default egress port listened by sidecar for routing local Java applications RPC request to another Java application     |
-| Sidecar     | 13009      | The default registry and discovery port listened by sidecar, for handling local Java application's Eureka/Conslu/Nacos APIs |
-| Agent       | 9000       | The default health port listened by Agent queried by sidecar for checking the liveness of Java application                  |
-| Application | customized | The port listened by Java application. Sidecar will use it for routing ingress traffic                                      |
+| Role        | Port       | Description                                                                                                                    |
+| ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Sidecar     | 13001      | The default Ingress port listened by the sidecar for accepting traffic and routing to the local application                    |
+| Sidecar     | 13002      | The default egress port listened by the sidecar for routing local application's RPC request to another application             |
+| Sidecar     | 13009      | The default registry and discovery port listened by the sidecar, for handling local application's Eureka/Conslu/Nacos requests |
+| Agent       | 9000       | The default health port listened by the agent, and queried by the sidecar for checking the liveness of the local application   |
+| Application | customized | The port listened by the local application. The sidecar will use it for routing the ingress traffic                            |
 
 
 

--- a/docs/sidecar_protocol.md
+++ b/docs/sidecar_protocol.md
@@ -40,9 +40,9 @@ The ports used by EaseMesh sidecar+agnet system
 To support the none-Java-spring-cloud-based RESTful-API application, regardless of which programming is used. The application must follow the protocol below
 
 
-1. It must serve as standard RESTful-API for handling requesting or invoking RPC. 
+1. It **must** serve as standard RESTful-API for handling requesting or invoking RPC. 
 
-2. It must use a domain for discovering in RESTful-API RPC.
+2. It **must** use a domain for discovering in RESTful-API RPC.
 ```
 Requirement:
 1. Use coreDNS with easemesh specific plugin
@@ -55,8 +55,10 @@ Requirement:
 
 ```
 
-3. It must serve the `http://localhost:9000/health` URI for EaseMesh health checking. (Only HTTP 200 return is required, regardless of the body content)
+3. It **must** serve the `http://localhost:9000/health` URI for EaseMesh health checking. (Only HTTP 200 return is required, regardless of the body content)
 
-4. It must reserve ports `13001` , `13002` and `13009` for local sidecar usage.
+4. It **must** reserve ports `13001` , `13002` and `13009` for local sidecar usage.
+
+5. It **should** specify the application port in Kubernetes deployment's `mesh.megaease.com/application-port` annotation for sidecar routing the ingress traffic. (If it is omitted, the port in deployment's first container's will be regarded as the application port)
 
 If an application obeys the protocol above, then EaseMesh can run it inside with sacrificed observability regardless of the implements programming language.

--- a/docs/sidecar_protocol.md
+++ b/docs/sidecar_protocol.md
@@ -59,6 +59,6 @@ Requirement:
 
 4. It **must** reserve ports `13001` , `13002` and `13009` for local sidecar usage.
 
-5. It **should** specify the application port in Kubernetes deployment's `mesh.megaease.com/application-port` annotation for sidecar routing the ingress traffic. (If it is omitted, the port in deployment's first container's will be regarded as the application port)
+5. It **should** specify the application port in Kubernetes deployment's `mesh.megaease.com/application-port` annotation for sidecar routing the ingress traffic. (If it is omitted, the first port of the first container will be regarded as the application port)
 
 If an application obeys the protocol above, then EaseMesh can run it inside with sacrificed observability regardless of the implements programming language.


### PR DESCRIPTION
* Sidecar need to know where to route the mesh-rpc-ingress traffic. 