### PR TITLE
shadow service install

### DIFF
--- a/emctl/cmd/client/command/flags/flags.go
+++ b/emctl/cmd/client/command/flags/flags.go
@@ -36,9 +36,6 @@ const (
 	// DefaultMeshIngressReplicas is default number of the mesh ingress service's replicas
 	DefaultMeshIngressReplicas = 1
 
-	// DefaultShadowServiceControllerReplicas is default number of the shadow service controller's replicas
-	DefaultShadowServiceControllerReplicas = 1
-
 	// DefaultMeshOperatorReplicas is default number of the operator's  replicas
 	DefaultMeshOperatorReplicas = 1
 
@@ -162,10 +159,9 @@ type (
 		MeshIngressReplicas    int
 		MeshIngressServicePort int32
 
-		OnlyAddOn                       bool
-		AddOns                          []string
-		ShadowServiceControllerImage    string
-		ShadowServiceControllerReplicas int
+		OnlyAddOn                    bool
+		AddOns                       []string
+		ShadowServiceControllerImage string
 
 		// EaseMesh Controller  params
 		EaseMeshRegistryType string
@@ -266,7 +262,6 @@ func (i *Install) AttachCmd(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&i.OnlyAddOn, "only-add-on", false, "Only install add-ons")
 	cmd.Flags().StringArrayVar(&i.AddOns, "add-ons", []string{}, "Names of add-ons to be installed")
 	cmd.Flags().StringVar(&i.ShadowServiceControllerImage, "shadowservice-controller-image", DefaultShadowServiceControllerImage, "Shadow service controller image name")
-	cmd.Flags().IntVar(&i.ShadowServiceControllerReplicas, "shadowservice-controller-replicas", DefaultShadowServiceControllerReplicas, "Shadow service controller replicas")
 	cmd.Flags().IntVar(&i.EaseMeshOperatorReplicas, "easemesh-operator-replicas", DefaultMeshOperatorReplicas, "Mesh operator controller replicas")
 	cmd.Flags().StringVarP(&i.SpecFile, "file", "f", "", "A yaml file specifying the install params")
 	cmd.Flags().BoolVar(&i.CleanWhenFailed, "clean-when-failed", true, "Clean resources when installation failed")

--- a/emctl/cmd/client/command/flags/flags.go
+++ b/emctl/cmd/client/command/flags/flags.go
@@ -183,6 +183,8 @@ type (
 	// Reset holds the option for the EaseMesh resest sub command
 	Reset struct {
 		*OperationGlobal
+		OnlyAddOn bool
+		AddOns    []string
 	}
 
 	// AdminGlobal holds the option for all the EaseMesh admin command
@@ -275,6 +277,8 @@ func (i *Install) AttachCmd(cmd *cobra.Command) {
 func (r *Reset) AttachCmd(cmd *cobra.Command) {
 	r.OperationGlobal = &OperationGlobal{}
 	r.OperationGlobal.AttachCmd(cmd)
+	cmd.Flags().BoolVar(&r.OnlyAddOn, "only-add-on", false, "Only reset add-ons")
+	cmd.Flags().StringArrayVar(&r.AddOns, "add-ons", []string{}, "Names of add-ons to be reset")
 }
 
 // AttachCmd attaches options globally

--- a/emctl/cmd/client/command/flags/flags.go
+++ b/emctl/cmd/client/command/flags/flags.go
@@ -36,6 +36,9 @@ const (
 	// DefaultMeshIngressReplicas is default number of the mesh ingress service's replicas
 	DefaultMeshIngressReplicas = 1
 
+	// DefaultShadowServiceControllerReplicas is default number of the shadow service controller's replicas
+	DefaultShadowServiceControllerReplicas = 1
+
 	// DefaultMeshOperatorReplicas is default number of the operator's  replicas
 	DefaultMeshOperatorReplicas = 1
 
@@ -119,6 +122,8 @@ spec:
 	DefaultEasegressImage = "megaease/easegress:latest"
 	// DefaultEaseMeshOperatorImage is default name of the operator docker image
 	DefaultEaseMeshOperatorImage = "megaease/easemesh-operator:latest"
+	// DefaultShadowServiceControllerImage is default name of the shadow service docker image
+	DefaultShadowServiceControllerImage = "megaease/easemesh-shadowservice-controller:latest"
 	// DefaultImageRegistryURL is default registry url
 	DefaultImageRegistryURL = "docker.io"
 )
@@ -156,6 +161,11 @@ type (
 
 		MeshIngressReplicas    int
 		MeshIngressServicePort int32
+
+		OnlyAddOn                       bool
+		AddOns                          []string
+		ShadowServiceControllerImage    string
+		ShadowServiceControllerReplicas int
 
 		// EaseMesh Controller  params
 		EaseMeshRegistryType string
@@ -251,6 +261,10 @@ func (i *Install) AttachCmd(cmd *cobra.Command) {
 
 	cmd.Flags().IntVar(&i.EasegressControlPlaneReplicas, "easemesh-control-plane-replicas", DefaultMeshControlPlaneReplicas, "Mesh control plane replicas")
 	cmd.Flags().IntVar(&i.MeshIngressReplicas, "easemesh-ingress-replicas", DefaultMeshIngressReplicas, "Mesh ingress controller replicas")
+	cmd.Flags().BoolVar(&i.OnlyAddOn, "only-add-on", false, "Only install add-ons")
+	cmd.Flags().StringArrayVar(&i.AddOns, "add-ons", []string{}, "Names of add-ons to be installed")
+	cmd.Flags().StringVar(&i.ShadowServiceControllerImage, "shadowservice-controller-image", DefaultShadowServiceControllerImage, "Shadow service controller image name")
+	cmd.Flags().IntVar(&i.ShadowServiceControllerReplicas, "shadowservice-controller-replicas", DefaultShadowServiceControllerReplicas, "Shadow service controller replicas")
 	cmd.Flags().IntVar(&i.EaseMeshOperatorReplicas, "easemesh-operator-replicas", DefaultMeshOperatorReplicas, "Mesh operator controller replicas")
 	cmd.Flags().StringVarP(&i.SpecFile, "file", "f", "", "A yaml file specifying the install params")
 	cmd.Flags().BoolVar(&i.CleanWhenFailed, "clean-when-failed", true, "Clean resources when installation failed")

--- a/emctl/cmd/client/command/mesh_install.go
+++ b/emctl/cmd/client/command/mesh_install.go
@@ -71,6 +71,21 @@ func InstallCmd() *cobra.Command {
 	return cmd
 }
 
+// uniqueAddOn removes duplicated add-on names and convert all the names to lower case
+func uniqueAddOn(addOns []string) []string {
+	m := make(map[string]bool)
+	result := []string{}
+	for _, addon := range addOns {
+		addon = strings.ToLower(addon)
+		if m[addon] {
+			continue
+		}
+		m[addon] = true
+		result = append(result, addon)
+	}
+	return result
+}
+
 func install(cmd *cobra.Command, flags *flags.Install) {
 	var err error
 	kubeClient, err := installbase.NewKubernetesClient()
@@ -102,13 +117,7 @@ func install(cmd *cobra.Command, flags *flags.Install) {
 		)
 	}
 
-	addons := make(map[string]bool)
-	for _, addon := range flags.AddOns {
-		addon = strings.ToLower(addon)
-		if addons[addon] {
-			continue
-		}
-		addons[addon] = true
+	for _, addon := range uniqueAddOn(flags.AddOns) {
 		switch addon {
 		case "shadowservice":
 			stages = append(stages, installation.Wrap(shadowservice.PreCheck, shadowservice.Deploy, shadowservice.Clear, shadowservice.DescribePhase))

--- a/emctl/cmd/client/command/mesh_reset.go
+++ b/emctl/cmd/client/command/mesh_reset.go
@@ -42,12 +42,28 @@ func reset(cmd *cobra.Command, resetFlags *flags.Reset) {
 		common.ExitWithErrorf("%s failed: %v", cmd.Short, err)
 	}
 
-	clearFuncs := []installation.ClearFunc{
-		shadowservice.Clear,
-		meshingress.Clear,
-		operator.Clear,
-		controlpanel.Clear,
-		crd.Clear,
+	var clearFuncs []installation.ClearFunc
+	if resetFlags.OnlyAddOn {
+		for _, addon := range uniqueAddOn(resetFlags.AddOns) {
+			switch addon {
+			case "shadowservice":
+				clearFuncs = append(clearFuncs, shadowservice.Clear)
+			default:
+				common.ExitWithErrorf("unknown add-on name: %s", addon)
+			}
+		}
+		if len(clearFuncs) == 0 {
+			common.ExitWithErrorf("nothing to reset")
+		}
+	} else {
+		// clear everything
+		clearFuncs = []installation.ClearFunc{
+			shadowservice.Clear,
+			meshingress.Clear,
+			operator.Clear,
+			controlpanel.Clear,
+			crd.Clear,
+		}
 	}
 
 	stageContext := installbase.StageContext{

--- a/emctl/cmd/client/command/mesh_reset.go
+++ b/emctl/cmd/client/command/mesh_reset.go
@@ -25,6 +25,7 @@ import (
 	"github.com/megaease/easemeshctl/cmd/client/command/meshinstall/installation"
 	"github.com/megaease/easemeshctl/cmd/client/command/meshinstall/meshingress"
 	"github.com/megaease/easemeshctl/cmd/client/command/meshinstall/operator"
+	"github.com/megaease/easemeshctl/cmd/client/command/meshinstall/shadowservice"
 	"github.com/megaease/easemeshctl/cmd/common"
 
 	"github.com/spf13/cobra"
@@ -42,6 +43,7 @@ func reset(cmd *cobra.Command, resetFlags *flags.Reset) {
 	}
 
 	clearFuncs := []installation.ClearFunc{
+		shadowservice.Clear,
 		meshingress.Clear,
 		operator.Clear,
 		controlpanel.Clear,
@@ -62,7 +64,6 @@ func reset(cmd *cobra.Command, resetFlags *flags.Reset) {
 			common.OutputErrorf("ignored a reseting resource error %s", err)
 		}
 	}
-
 }
 
 // ResetCmd invoke reset sub command entrypoint

--- a/emctl/cmd/client/command/meshclient/meshclient.go
+++ b/emctl/cmd/client/command/meshclient/meshclient.go
@@ -62,6 +62,7 @@ var _ V1Alpha1Interface = &v1alpha1Interface{}
 
 // New initials a new MeshClient
 func New(server string) MeshClient {
+	server = strings.TrimPrefix(server, "http://")
 
 	if isTest {
 		// This is for test, in the unit test we will create a mock MeshClient

--- a/emctl/cmd/client/command/meshinstall/base/const.go
+++ b/emctl/cmd/client/command/meshinstall/base/const.go
@@ -92,6 +92,8 @@ const (
 	DefaultMeshIngressService = "easemesh-ingress-service"
 	//DefaultMeshIngressControllerName is the default deployment name of the meshingress.
 	DefaultMeshIngressControllerName = "easemesh-ingress-easegress"
+	//DefaultShadowServiceControllerName is the default deployment name of the shadow service controller.
+	DefaultShadowServiceControllerName = "easemesh-shadowservice-controller"
 
 	// DefaultKubeDir represents default kubernetes client configuration directory.
 	DefaultKubeDir = ".kube"

--- a/emctl/cmd/client/command/meshinstall/meshingress/deployment_spec.go
+++ b/emctl/cmd/client/command/meshinstall/meshingress/deployment_spec.go
@@ -140,8 +140,24 @@ func (v *containerVisitor) VisitorContainerPorts(c *v1.Container) ([]v1.Containe
 }
 
 func (v *containerVisitor) VisitorEnvs(c *v1.Container) ([]v1.EnvVar, error) {
-
-	return nil, nil
+	return []v1.EnvVar{
+		{
+			Name: "HOSTNAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "APPLICATION_IP",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		},
+	}, nil
 }
 func (v *containerVisitor) VisitorEnvFrom(c *v1.Container) ([]v1.EnvFromSource, error) {
 

--- a/emctl/cmd/client/command/meshinstall/shadowservice/customresource.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/customresource.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shadowservice
+
+import (
+	"github.com/megaease/easemeshctl/cmd/client/command/meshclient"
+	installbase "github.com/megaease/easemeshctl/cmd/client/command/meshinstall/base"
+	"github.com/megaease/easemeshctl/cmd/client/resource"
+	"gopkg.in/yaml.v2"
+)
+
+const shadowServiceKind = `kind: CustomResourceKind
+apiVersion: mesh.megaease.com/v1alpla1
+metadata:
+  name: ShadowService
+spec:
+  jsonSchema:
+    type: object
+    properties:
+      name:
+        type: string
+      namespace:
+        type: string
+      serviceName:
+        type: string
+      mysql:
+        type: object
+        properties:
+          uris:
+            type: string
+          userName:
+            type: string
+          password:
+            type: string
+      kafka:
+        type: object
+        properties:
+          uris:
+            type: string
+      redis:
+        type: object
+        properties:
+          uris:
+            type: string
+          userName:
+            type: string
+          password:
+            type: string
+      rabbitMq:
+        type: object
+        properties:
+          uris:
+            type: string
+          userName:
+            type: string
+          password:
+            type: string
+      elasticSearch:
+        type: object
+        properties:
+          uris:
+            type: string
+          userName:
+            type: string
+          password:
+            type: string`
+
+func shadowServiceKindSpec(ctx *installbase.StageContext) installbase.InstallFunc {
+	return func(ctx *installbase.StageContext) error {
+		entrypoints, err := installbase.GetMeshControlPlaneEndpoints(ctx.Client, ctx.Flags.MeshNamespace,
+			installbase.DefaultMeshControlPlanePlubicServiceName,
+			installbase.DefaultMeshAdminPortName)
+		if err != nil {
+			return err
+		}
+
+		var kind resource.CustomResourceKind
+		err = yaml.Unmarshal([]byte(shadowServiceKind), &kind)
+		if err != nil {
+			return err
+		}
+		client := meshclient.New(entrypoints[0])
+		return client.V1Alpha1().CustomResourceKind().Create(ctx.Cmd.Context(), &kind)
+	}
+}
+
+func deleteShadowServiceKindSpec(ctx *installbase.StageContext) error {
+	entrypoints, err := installbase.GetMeshControlPlaneEndpoints(ctx.Client, ctx.Flags.MeshNamespace,
+		installbase.DefaultMeshControlPlanePlubicServiceName,
+		installbase.DefaultMeshAdminPortName)
+	if err != nil {
+		return err
+	}
+
+	client := meshclient.New(entrypoints[0])
+	return client.V1Alpha1().CustomResourceKind().Delete(ctx.Cmd.Context(), "ShadowService")
+}

--- a/emctl/cmd/client/command/meshinstall/shadowservice/deploy.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/deploy.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shadowservice
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/megaease/easemeshctl/cmd/client/command/flags"
+	installbase "github.com/megaease/easemeshctl/cmd/client/command/meshinstall/base"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Deploy deploy resources of shadow service controller
+func Deploy(ctx *installbase.StageContext) error {
+	err := installbase.BatchDeployResources(ctx, []installbase.InstallFunc{
+		deploymentSpec(ctx),
+		shadowServiceKindSpec(ctx),
+	})
+	if err != nil {
+		return err
+	}
+
+	return checkShadowServiceStatus(ctx.Client, ctx.Flags)
+}
+
+// PreCheck check prerequisite for installing shadow service controller
+func PreCheck(context *installbase.StageContext) error {
+	return nil
+}
+
+// Clear will clear all installed resource about shadow service controller
+func Clear(context *installbase.StageContext) error {
+	deleteShadowServiceKindSpec(context)
+	appsV1Resources := [][]string{
+		{"deployments", installbase.DefaultShadowServiceControllerName},
+	}
+	installbase.DeleteResources(context.Client, appsV1Resources, context.Flags.MeshNamespace, installbase.DeleteAppsV1Resource)
+	return nil
+}
+
+// DescribePhase leverage human-readable text to describe different phase
+// in the process of the shadow service controller
+func DescribePhase(context *installbase.StageContext, phase installbase.InstallPhase) string {
+	switch phase {
+	case installbase.BeginPhase:
+		return fmt.Sprintf("Begin to install shadow service controller in the namespace:%s", context.Flags.MeshNamespace)
+	case installbase.EndPhase:
+		return fmt.Sprintf("\nShadow service controller deployed successfully, deployment:%s\n%s", installbase.DefaultShadowServiceControllerName,
+			installbase.FormatPodStatus(context.Client, context.Flags.MeshNamespace,
+				installbase.AdaptListPodFunc(shadowServiceLabel())))
+	}
+	return ""
+}
+
+func checkShadowServiceStatus(client kubernetes.Interface, installFlags *flags.Install) error {
+	i := 0
+	for {
+		time.Sleep(time.Millisecond * 100)
+		i++
+		if i > 600 {
+			return errors.Errorf("easeMesh shadow service controller deploy failed, shadow service controller (EG deployment) not ready")
+		}
+		ready, err := installbase.CheckDeploymentResourceStatus(client, installFlags.MeshNamespace,
+			installbase.DefaultShadowServiceControllerName,
+			installbase.DeploymentReadyPredict)
+		if ready {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/emctl/cmd/client/command/meshinstall/shadowservice/deploy.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/deploy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/megaease/easemeshctl/cmd/client/command/flags"
 	installbase "github.com/megaease/easemeshctl/cmd/client/command/meshinstall/base"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 )

--- a/emctl/cmd/client/command/meshinstall/shadowservice/deploy.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/deploy.go
@@ -30,6 +30,8 @@ import (
 // Deploy deploy resources of shadow service controller
 func Deploy(ctx *installbase.StageContext) error {
 	err := installbase.BatchDeployResources(ctx, []installbase.InstallFunc{
+		clusterRoleSpec(ctx),
+		clusterRoleBindingSpec(ctx),
 		deploymentSpec(ctx),
 		shadowServiceKindSpec(ctx),
 	})

--- a/emctl/cmd/client/command/meshinstall/shadowservice/deploy_test.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/deploy_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shadowservice
+
+import (
+	"testing"
+
+	"github.com/megaease/easemeshctl/cmd/client/command/flags"
+	installbase "github.com/megaease/easemeshctl/cmd/client/command/meshinstall/base"
+	meshtesting "github.com/megaease/easemeshctl/cmd/client/testing"
+
+	"github.com/spf13/cobra"
+	extensionfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func prepareContext() (*installbase.StageContext, *fake.Clientset, *extensionfake.Clientset) {
+	client := fake.NewSimpleClientset()
+	extensionClient := extensionfake.NewSimpleClientset()
+
+	install := &flags.Install{}
+	cmd := &cobra.Command{}
+	install.AttachCmd(cmd)
+	return meshtesting.PrepareInstallContext(cmd, client, extensionClient, install), client, extensionClient
+}
+
+func TestDeploy(t *testing.T) {
+	ctx, _, _ := prepareContext()
+
+	for _, f := range []func(*installbase.StageContext) installbase.InstallFunc{
+		deploymentSpec, shadowServiceKindSpec,
+	} {
+		f(ctx).Deploy(ctx)
+	}
+
+	Deploy(ctx)
+
+}
+
+func TestDescribePhase(t *testing.T) {
+	ctx, _, _ := prepareContext()
+	DescribePhase(ctx, installbase.BeginPhase)
+	DescribePhase(ctx, installbase.EndPhase)
+	DescribePhase(ctx, installbase.ErrorPhase)
+	PreCheck(ctx)
+}

--- a/emctl/cmd/client/command/meshinstall/shadowservice/deployment_spec.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/deployment_spec.go
@@ -65,8 +65,6 @@ func deploymentBaseSpec(fn deploymentSpecFunc) deploymentSpecFunc {
 			MatchLabels: shadowServiceLabel(),
 		}
 
-		var replicas = int32(installFlags.ShadowServiceControllerReplicas)
-		spec.Spec.Replicas = &replicas
 		spec.Spec.Template.Labels = shadowServiceLabel()
 		spec.Spec.Template.Spec.Containers = []v1.Container{}
 		return spec

--- a/emctl/cmd/client/command/meshinstall/shadowservice/deployment_spec.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/deployment_spec.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shadowservice
+
+import (
+	"fmt"
+
+	"github.com/megaease/easemeshctl/cmd/client/command/flags"
+	installbase "github.com/megaease/easemeshctl/cmd/client/command/meshinstall/base"
+
+	"github.com/pkg/errors"
+	appsV1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type deploymentSpecFunc func(*flags.Install) *appsV1.Deployment
+
+func shadowServiceLabel() map[string]string {
+	selector := map[string]string{}
+	selector["app"] = "easemesh-shadowservice-controller"
+	return selector
+}
+
+func deploymentSpec(ctx *installbase.StageContext) installbase.InstallFunc {
+	deployment := deploymentContainerSpec(
+		deploymentBaseSpec(
+			deploymentInitialize(nil)))(ctx.Flags)
+
+	return func(ctx *installbase.StageContext) error {
+		err := installbase.DeployDeployment(deployment, ctx.Client, ctx.Flags.MeshNamespace)
+		if err != nil {
+			return errors.Wrapf(err, "deployment operation %s failed", deployment.Name)
+		}
+		return err
+	}
+}
+
+func deploymentInitialize(fn deploymentSpecFunc) deploymentSpecFunc {
+	return func(installFlags *flags.Install) *appsV1.Deployment {
+		return &appsV1.Deployment{}
+	}
+}
+
+func deploymentBaseSpec(fn deploymentSpecFunc) deploymentSpecFunc {
+	return func(installFlags *flags.Install) *appsV1.Deployment {
+		spec := fn(installFlags)
+		spec.Name = installbase.DefaultShadowServiceControllerName
+		spec.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: shadowServiceLabel(),
+		}
+
+		var replicas = int32(installFlags.ShadowServiceControllerReplicas)
+		spec.Spec.Replicas = &replicas
+		spec.Spec.Template.Labels = shadowServiceLabel()
+		spec.Spec.Template.Spec.Containers = []v1.Container{}
+		return spec
+	}
+}
+
+func deploymentContainerSpec(fn deploymentSpecFunc) deploymentSpecFunc {
+	return func(installFlags *flags.Install) *appsV1.Deployment {
+
+		spec := fn(installFlags)
+		container, _ := installbase.AcceptContainerVisitor("shadowservice-controller",
+			installFlags.ImageRegistryURL+"/"+installFlags.ShadowServiceControllerImage,
+			v1.PullIfNotPresent,
+			newVisitor(installFlags))
+
+		spec.Spec.Template.Spec.Containers = append(spec.Spec.Template.Spec.Containers, *container)
+		return spec
+	}
+}
+
+type containerVisitor struct {
+	installFlags *flags.Install
+}
+
+func newVisitor(installFlags *flags.Install) installbase.ContainerVisitor {
+	return &containerVisitor{installFlags}
+}
+
+func (v *containerVisitor) VisitorCommandAndArgs(c *v1.Container) (command []string, installFlags []string) {
+	cmds := []string{"/bin/sh"}
+	meshServer := fmt.Sprintf("%s.%s:%d", v.installFlags.EgServiceName, v.installFlags.MeshNamespace, v.installFlags.EgAdminPort)
+	args := []string{
+		"-c",
+		"/opt/easemesh-shadowservice/bin/easemesh-shadowservice-controller -mesh-server " + meshServer,
+	}
+	return cmds, args
+}
+
+func (v *containerVisitor) VisitorContainerPorts(c *v1.Container) ([]v1.ContainerPort, error) {
+	return []v1.ContainerPort{}, nil
+}
+
+func (v *containerVisitor) VisitorEnvs(c *v1.Container) ([]v1.EnvVar, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorEnvFrom(c *v1.Container) ([]v1.EnvFromSource, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorResourceRequirements(c *v1.Container) (*v1.ResourceRequirements, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorVolumeMounts(c *v1.Container) ([]v1.VolumeMount, error) {
+	return []v1.VolumeMount{}, nil
+}
+
+func (v *containerVisitor) VisitorVolumeDevices(c *v1.Container) ([]v1.VolumeDevice, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorLivenessProbe(c *v1.Container) (*v1.Probe, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorReadinessProbe(c *v1.Container) (*v1.Probe, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorLifeCycle(c *v1.Container) (*v1.Lifecycle, error) {
+	return nil, nil
+}
+
+func (v *containerVisitor) VisitorSecurityContext(c *v1.Container) (*v1.SecurityContext, error) {
+	return nil, nil
+}

--- a/emctl/cmd/client/command/meshinstall/shadowservice/rbac_spec.go
+++ b/emctl/cmd/client/command/meshinstall/shadowservice/rbac_spec.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shadowservice
+
+import (
+	installbase "github.com/megaease/easemeshctl/cmd/client/command/meshinstall/base"
+
+	"github.com/pkg/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func clusterRoleSpec(ctx *installbase.StageContext) installbase.InstallFunc {
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "namespace-lister"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"list"},
+			},
+		},
+	}
+
+	return func(ctx *installbase.StageContext) error {
+		err := installbase.DeployClusterRole(clusterRole, ctx.Client)
+		if err != nil {
+			return errors.Wrapf(err, "createClusterRole role %s", clusterRole.Name)
+		}
+		return nil
+	}
+}
+
+func clusterRoleBindingSpec(ctx *installbase.StageContext) installbase.InstallFunc {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "list-namespaces",
+			Namespace: ctx.Flags.MeshNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "namespace-lister",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: ctx.Flags.MeshNamespace,
+			},
+		},
+	}
+
+	return func(ctx *installbase.StageContext) error {
+		err := installbase.DeployClusterRoleBinding(clusterRoleBinding, ctx.Client)
+		if err != nil {
+			return errors.Wrapf(err, "Create roleBinding %s", clusterRoleBinding.Name)
+		}
+		return nil
+	}
+}

--- a/emctl/cmd/client/resource/resource_test.go
+++ b/emctl/cmd/client/resource/resource_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/megaease/easemesh-api/v1alpha1"
 	"github.com/megaease/easemeshctl/cmd/client/resource/meta"
+	"gopkg.in/yaml.v2"
 )
 
 func TestObjectCreator(t *testing.T) {
@@ -98,5 +99,30 @@ func TestObjectCreator(t *testing.T) {
 			}).ToV1Alpha1()
 		}
 
+	}
+}
+
+func TestDynamicObject(t *testing.T) {
+	r := DynamicObject{}
+	r["field1"] = map[string]interface{}{
+		"sub1": 1,
+		"sub2": "value2",
+	}
+	r["field2"] = []interface{}{
+		"sub1", "sub2",
+	}
+
+	data, err := yaml.Marshal(r)
+	if err != nil {
+		t.Errorf("yaml.Marshal should succeed: %v", err.Error())
+	}
+
+	err = yaml.Unmarshal(data, &r)
+	if err != nil {
+		t.Errorf("yaml.Marshal should succeed: %v", err.Error())
+	}
+
+	if _, ok := r["field1"].(map[string]interface{}); !ok {
+		t.Errorf("the type of 'field1' should be 'map[string]interface{}'")
 	}
 }


### PR DESCRIPTION
Because shadow service is an optional component, two new flags are added to `emctl install` command
* **--only-add-on** to only install add-ons when EaseMesh infrastructure is already installed
* **--add-ons=** to specify the names of add-ons to install

Default `emctl reset` command uninstalls all installed add-ons, `--only-add-on` and `--add-ons=` could be specified to only uninstall add-ons.

we will need a new command like `emctl install-add-on` for better add-on management later.